### PR TITLE
Add java and maven as a dep

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "jgo" %}
 {% set version = "0.1.0" %}
+{% set build_number = 1 %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +11,7 @@ source:
   sha256: 880d880badc2b3ec88ed15f063be3fe12c83eec5c951b743b182b66d81977188
 
 build:
-  number: 0
+  number: {{ build_number }}
   script: "{{ PYTHON }} -m pip install . -vvv"
   skip: True  # [py2k]
 


### PR DESCRIPTION
@ctrueden @hanslovsky 

I got an error during `imglyb` tests because maven was missing.

Are you ok adding Java and maven as a dependency of jgo?